### PR TITLE
FOREGROUND_SERVICE permission required on Android 9 to launch foreground services

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <permission android:name="com.zacharee1.permission.RUN_SERVICE" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.android.vending.BILLING" />


### PR DESCRIPTION
As described in a note [here](https://developer.android.com/guide/components/services#Foreground), the FOREGROUND_SERVICE permission is now required to launch a foreground service on Android 9 when targeting API level 28.
Without that, the latest master build crashes when enabling Safe Mode.