### PR TITLE
OnePlus native call recording setting

### DIFF
--- a/app/src/main/java/com/zacharee1/systemuituner/fragments/MiscFragment.kt
+++ b/app/src/main/java/com/zacharee1/systemuituner/fragments/MiscFragment.kt
@@ -30,6 +30,7 @@ class MiscFragment : AnimFragment() {
             setNightModeSwitchStates()
             setUpAnimationScales()
             setUpSnoozeStuff()
+            removeOnePlusIfNeeded()
         }
     }
 
@@ -74,11 +75,13 @@ class MiscFragment : AnimFragment() {
         }
 
         // OnePlus call recording
-        val preference = findPreference(ONE_PLUS_CALL_RECORDER) as SwitchPreference
-        preference.isChecked = Settings.Global.getInt(context?.contentResolver, ONE_PLUS_CALL_RECORDER, 0) == 1
-        preference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, o ->
-            context.writeGlobal(ONE_PLUS_CALL_RECORDER, if (o.toString().toBoolean()) 1 else 0)
-            true
+        if (checkOnePlusWithCallRecording()) {
+            val preference = findPreference(ONE_PLUS_CALL_RECORDER) as SwitchPreference
+            preference.isChecked = Settings.Global.getInt(context?.contentResolver, ONE_PLUS_CALL_RECORDER, 0) == 1
+            preference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, o ->
+                context.writeGlobal(ONE_PLUS_CALL_RECORDER, if (o.toString().toBoolean()) 1 else 0)
+                true
+            }
         }
     }
 
@@ -358,6 +361,12 @@ class MiscFragment : AnimFragment() {
         }
 
         return ret
+    }
+
+    private fun removeOnePlusIfNeeded() {
+        if (!checkOnePlusWithCallRecording()) {
+            preferenceScreen.removePreference(findPreference("call_recording") ?: return)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/zacharee1/systemuituner/fragments/MiscFragment.kt
+++ b/app/src/main/java/com/zacharee1/systemuituner/fragments/MiscFragment.kt
@@ -11,13 +11,13 @@ import android.preference.SwitchPreference
 import android.provider.Settings
 import com.pavelsikun.seekbarpreference.SeekBarPreference
 import com.zacharee1.systemuituner.R
-import com.zacharee1.systemuituner.util.writeGlobal
-import com.zacharee1.systemuituner.util.writeSecure
-import com.zacharee1.systemuituner.util.writeSystem
+import com.zacharee1.systemuituner.services.SafeModeService
+import com.zacharee1.systemuituner.util.*
 import java.util.*
 
 class MiscFragment : AnimFragment() {
     private var origSnooze = false
+    private var origCallRecording = false
 
     override fun onSetTitle() = resources.getString(R.string.miscellaneous)
 
@@ -37,10 +37,12 @@ class MiscFragment : AnimFragment() {
         super.onCreate(savedInstanceState)
 
         preferenceManager.sharedPreferences.apply {
-            origSnooze = getBoolean("safe_mode_snooze_options", true)
+            origSnooze = getBoolean(SafeModeService.SAFE_MODE_SNOOZE_OPTIONS, true)
+            origCallRecording = getBoolean(SafeModeService.SAFE_MODE_CALL_RECORDING, true)
 
             edit().apply {
-                putBoolean("safe_mode_snooze_options", false)
+                putBoolean(SafeModeService.SAFE_MODE_SNOOZE_OPTIONS, false)
+                putBoolean(SafeModeService.SAFE_MODE_CALL_RECORDING, false)
             }.apply()
         }
     }
@@ -49,7 +51,8 @@ class MiscFragment : AnimFragment() {
         super.onDestroy()
 
         preferenceManager.sharedPreferences.edit().apply {
-            putBoolean("safe_mode_snooze_options", origSnooze)
+            putBoolean(SafeModeService.SAFE_MODE_SNOOZE_OPTIONS, origSnooze)
+            putBoolean(SafeModeService.SAFE_MODE_CALL_RECORDING, origCallRecording)
         }.apply()
     }
 
@@ -68,6 +71,14 @@ class MiscFragment : AnimFragment() {
                 context.writeGlobal(key, if (o.toString().toBoolean()) 3 else 2)
                 true
             }
+        }
+
+        // OnePlus call recording
+        val preference = findPreference(ONE_PLUS_CALL_RECORDER) as SwitchPreference
+        preference.isChecked = Settings.Global.getInt(context?.contentResolver, ONE_PLUS_CALL_RECORDER, 0) == 1
+        preference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, o ->
+            context.writeGlobal(ONE_PLUS_CALL_RECORDER, if (o.toString().toBoolean()) 1 else 0)
+            true
         }
     }
 
@@ -365,6 +376,7 @@ class MiscFragment : AnimFragment() {
         const val NIGHT_DISPLAY_ACTIVATED = "night_display_activated"
         const val NIGHT_DISPLAY_AUTO = "night_display_auto"
         const val NIGHT_MODE_SETTINGS = "night_mode_settings"
+        const val ONE_PLUS_CALL_RECORDER = "op_voice_recording_supported_by_mcc"
 
         private const val TWILIGHT_MODE_INACTIVE = 0
         private const val TWILIGHT_MODE_OVERRIDE = 1

--- a/app/src/main/java/com/zacharee1/systemuituner/services/SafeModeService.kt
+++ b/app/src/main/java/com/zacharee1/systemuituner/services/SafeModeService.kt
@@ -24,10 +24,7 @@ import com.zacharee1.systemuituner.fragments.StatbarFragment
 import com.zacharee1.systemuituner.fragments.StatbarFragment.Companion.ICON_BLACKLIST
 import com.zacharee1.systemuituner.fragments.StatbarFragment.Companion.ICON_BLACKLIST_BACKUP
 import com.zacharee1.systemuituner.fragments.TWFragment
-import com.zacharee1.systemuituner.util.checkSamsung
-import com.zacharee1.systemuituner.util.writeGlobal
-import com.zacharee1.systemuituner.util.writeSecure
-import com.zacharee1.systemuituner.util.writeSystem
+import com.zacharee1.systemuituner.util.*
 
 class SafeModeService : Service() {
     companion object {
@@ -210,7 +207,7 @@ class SafeModeService : Service() {
     }
 
     private fun restoreCallRecorder() {
-        if (callRecorder) {
+        if (callRecorder && checkOnePlusWithCallRecording()) {
             val callRecorder = preferences.getBoolean(MiscFragment.ONE_PLUS_CALL_RECORDER, true)
 
             writeGlobal(MiscFragment.ONE_PLUS_CALL_RECORDER, if (callRecorder) 1 else 0)

--- a/app/src/main/java/com/zacharee1/systemuituner/services/SafeModeService.kt
+++ b/app/src/main/java/com/zacharee1/systemuituner/services/SafeModeService.kt
@@ -40,6 +40,7 @@ class SafeModeService : Service() {
         const val SAFE_MODE_SNOOZE_OPTIONS = "safe_mode_snooze_options"
         const val SAFE_MODE_HIGH_BRIGHTNESS_WARNING = "safe_mode_high_brightness_warning"
         const val SAFE_MODE_VOLUME_WARNING = "safe_mode_volume_warning"
+        const val SAFE_MODE_CALL_RECORDING = "safe_mode_call_recording"
         const val SAFE_MODE_NOTIF = "show_safe_mode_notif"
     }
 
@@ -77,6 +78,8 @@ class SafeModeService : Service() {
         get() = preferences.getBoolean(SAFE_MODE_HIGH_BRIGHTNESS_WARNING, true)
     private val volumeWarning: Boolean
         get() = preferences.getBoolean(SAFE_MODE_VOLUME_WARNING, true)
+    private val callRecorder: Boolean
+        get() = preferences.getBoolean(SAFE_MODE_CALL_RECORDING, true)
 
     private val prefsListener: SharedPreferences.OnSharedPreferenceChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { preferences, key ->
         when (key) {
@@ -108,6 +111,8 @@ class SafeModeService : Service() {
         setUpContentObserver()
         restoreSnoozeState()
         restoreVolumeWarning()
+        restoreCallRecorder()
+
         return Service.START_STICKY
     }
 
@@ -201,6 +206,14 @@ class SafeModeService : Service() {
             val warn = preferences.getBoolean(MiscFragment.AUDIO_SAFE, true)
 
             writeGlobal(MiscFragment.AUDIO_SAFE, if (warn) 3 else 2)
+        }
+    }
+
+    private fun restoreCallRecorder() {
+        if (callRecorder) {
+            val callRecorder = preferences.getBoolean(MiscFragment.ONE_PLUS_CALL_RECORDER, true)
+
+            writeGlobal(MiscFragment.ONE_PLUS_CALL_RECORDER, if (callRecorder) 1 else 0)
         }
     }
 

--- a/app/src/main/java/com/zacharee1/systemuituner/util/UtilFunctions.kt
+++ b/app/src/main/java/com/zacharee1/systemuituner/util/UtilFunctions.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.preference.PreferenceFragment
 import android.preference.PreferenceManager
 import android.preference.SwitchPreference
@@ -154,6 +155,13 @@ fun checkMIUI(): Boolean {
 
     return false
 }
+
+// Native call recording doesn't seem to be available on OnePlus One (A000X), OnePlus X (E100X)
+// and OnePlus 2 (A200X) models
+private val onePlusOldModels = """^(ONEPLUS\s)*[AE][02]\d{3}$""".toRegex()
+
+fun checkOnePlusWithCallRecording() =
+        Build.MANUFACTURER == "OnePlus" && !onePlusOldModels.matches(Build.MODEL)
 
 fun Context.checkSamsung() =
         packageManager.hasSystemFeature("com.samsung.feature.samsung_experience_mobile")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="system">System</string>
     <string name="ok">OK</string>
     <string name="power_notification_controls">Power Notification Controls</string>
+    <string name="call_recording">Native Call Recording</string>
     <string name="danger_zone">Danger Zone</string>
     <string name="safe_mode">Safe Mode</string>
     <string name="enable_custom_settings_input">Enable Custom Settings</string>
@@ -263,6 +264,7 @@
     <string name="statbar_rotation_lock_notif">On certain devices, modifying the status bar icons can cause an icon that looks like a phone to appear. This is the rotation lock icon. Tap here to fix it.</string>
     <string name="pnc_desc">Power Notification Controls allow you to set the level of importance for notifications on a per-app basis. Simply turn the feature on and hold down on a notification to get started. You may need to tap the A to enable the slider.</string>
     <string name="pnc_warn">This feature is known to be unreliable on certain devices, especially on TouchWiz! It is impossible to fix, but the best workaround seems to be to tap repeatedly on the desired level. Again, I CANNOT fix it!</string>
+    <string name="call_recording_desc">Enable call recording in the default calling app on OnePlus devices (disabled by default in certain regions). Compatible with OnePlus 3 and newer.</string>
     <string name="notif_desc">Tap to change settings</string>
     <string name="touchwiz_oreo_qqs">On TouchWiz Oreo devices, this setting is no longer reliable! Along with setting the number here, you may have to also save the value to Settings.System.apanel_number, which can only be done with ADB or root. Safe Mode attempts to implement a workaround, but I can\'t guarantee it will work!</string>
     <string name="notifs_snooze_desc">&#160;
@@ -285,6 +287,7 @@
     <string name="safe_mode_volume_warning_desc">Restores current High Volume Warning state on boot.</string>
     <string name="safe_mode_needed_qs_row_col">Safe Mode must be turned on, with the Row/Column option activated, for landscape values to work.</string>
     <string name="safe_mode_inactive_on_current_page">Safe Mode is inactive on this screen! Go back to the main menu to save changes!</string>
+    <string name="safe_mode_call_recording_desc">Restores current Native Call Recording state on boot (OnePlus).</string>
 
     <!--Messages-->
     <string name="sorry_explain">Something went wrong while setting this toggle.</string>

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -110,4 +110,16 @@
             android:summary="@string/pnc_warn"/>
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/call_recording"
+        android:key="call_recording">
+        <SwitchPreference
+            android:key="op_voice_recording_supported_by_mcc"
+            android:title="@string/enabled"/>
+        <Preference
+            android:title="@string/about"
+            android:summary="@string/call_recording_desc"
+            android:selectable="false" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -97,6 +97,14 @@
             android:summary="@string/safe_mode_volume_warning_desc"
             />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="safe_mode"
+            android:key="safe_mode_call_recording"
+            android:title="@string/call_recording"
+            android:summary="@string/safe_mode_call_recording_desc"
+            />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Add a new setting in "Miscellaneous" to enable the call recording feature of the default OnePlus call app in regions where it is not enabled by default.
I also created a new Safe Mode option to restore this setting on boot.

It's working fine on my OnePlus 6. This setting shouldn't show up on non-compatible devices.

Fixes #23